### PR TITLE
fix "text" / "test" type

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -374,7 +374,7 @@
 				</section>
 				<section class="guideline"  data-status="exploratory">
 					<h4>Interaction indicators contrast</h4>
-					<p class="guideline-text">Interaction indicators meet a ‘minimum contrast ratio text’ and meet a minimum thickness.</p>
+					<p class="guideline-text">Interaction indicators meet a ‘minimum contrast ratio test’ and meet a minimum thickness.</p>
 					<p class="ednote">Needs <a href="#additional_research">additional research</a></p>
 				</section>
 				<section class="guideline"  data-status="exploratory">


### PR DESCRIPTION
Interaction Indicators Contrast description should be "minimum contrast ratio test", not "… text".